### PR TITLE
Minesweeper - complete features

### DIFF
--- a/minesweeper/minesweeper.py
+++ b/minesweeper/minesweeper.py
@@ -99,8 +99,8 @@ class Pos(QWidget):
         elif self.is_flagged:
             p.drawPixmap(r, QPixmap(IMG_FLAG))
 
-    def flag(self):
-        self.is_flagged = True
+    def toggle_flag(self):
+        self.is_flagged = not self.is_flagged
         self.update()
 
         self.clicked.emit()
@@ -120,7 +120,7 @@ class Pos(QWidget):
     def mouseReleaseEvent(self, e):
 
         if (e.button() == Qt.RightButton and not self.is_revealed):
-            self.flag()
+            self.toggle_flag()
 
         elif (e.button() == Qt.LeftButton):
             self.click()

--- a/minesweeper/minesweeper.py
+++ b/minesweeper/minesweeper.py
@@ -300,7 +300,7 @@ class MainWindow(QMainWindow):
 
     def get_revealable_around(self, x, y, force=False):
         for xi, yi, w in self.get_surrounding(x, y):
-            if (force or not w.is_mine) and not w.is_flagged:
+            if (force or not w.is_mine) and not w.is_flagged and not w.is_revealed:
                 yield (xi, yi, w)
 
     def expand_reveal(self, x, y, force=False):

--- a/minesweeper/minesweeper.py
+++ b/minesweeper/minesweeper.py
@@ -63,6 +63,7 @@ class Pos(QWidget):
 
         self.is_revealed = False
         self.is_flagged = False
+        self.is_end = False
 
         self.update()
 
@@ -75,6 +76,8 @@ class Pos(QWidget):
         if self.is_revealed:
             color = self.palette().color(QPalette.Background)
             outer, inner = color, color
+            if self.is_end:
+                inner = NUM_COLORS[1]
         else:
             outer, inner = Qt.gray, Qt.lightGray
 
@@ -118,6 +121,7 @@ class Pos(QWidget):
                 self.expandable.emit(self.x, self.y)
 
             if self.is_mine:
+                self.is_end = True
                 self.ohno.emit()
 
     def click(self):


### PR DESCRIPTION
Hi,

Thanks very much for this project, it is very useful for jump starting PyQt development :)

I found the Minesweeper game particularly interesting and decided to complete it's features. I thought I would share it here as a PR in case you would like these improvements in your repo for others to learn from / make this example game more enjoyable - I will totally understand if it is out of the project scope and you reject it, I wasn't sure if it was intentionally half finished so people could do exactly what I just did as a fun way to experiment or learn or because the example in its current state is perfect for demonstrating how to create Qt apps from Python. Apologies if this project goal is mentioned somewhere but I missed it.

Anyway, the changes I have made are, in no particular order:

- allow right clicking on a flagged cell to unflag it
- when flagging, reduce the number of remaining mines shown in the counter widget
- when unflagging, increase the number of remaining mines shown in the counter widget
- when revealing a mine and losing the game, mark the mine that caused game over in a different color
- when losing the game, show which flags were incorrect and keep those that were correct visible
- when right clicking on a revealed cell, intelligently reveal the cells around if the number of adjacent mines matches the number of adjacent flags (a feature Windows 95's "winmine" has)
- evaluate the winning conditions - when all the cells except the mines have been revealed
- use a common generator function to deduplicate some code and only evaluate the minimum number of cells necessary for the new logic
- set the window title
- allow the user to specify the difficulty level (0, 1 or 2) in the command line arguments to expose the otherwise hidden functionality
