### PR TITLE
calculator: fixes window not closing with the Exit menu

### DIFF
--- a/calculator/calculator.py
+++ b/calculator/calculator.py
@@ -33,6 +33,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.actionReset.triggered.connect(self.reset)
         self.pushButton_ac.pressed.connect(self.reset)
 
+        self.actionExit.triggered.connect(self.close)
+
         self.pushButton_m.pressed.connect(self.memory_store)
         self.pushButton_mr.pressed.connect(self.memory_recall)
 


### PR DESCRIPTION
Connects the actionExit action to the close() method of the window, allows the window to be closed using the File->Exit menu and the `Ctrl+Q` shortcut.