### PR TITLE
Added code to support multiple browser windows.  Fixes issue #7

### DIFF
--- a/browser/browser.py
+++ b/browser/browser.py
@@ -50,6 +50,7 @@ class MainWindow(QMainWindow):
 
         self.browser.urlChanged.connect(self.update_urlbar)
         self.browser.loadFinished.connect(self.update_title)
+        self.browser.createWindow = self.new_window
         self.setCentralWidget(self.browser)
 
         self.status = QStatusBar()
@@ -191,6 +192,15 @@ class MainWindow(QMainWindow):
         self.urlbar.setText(q.toString())
         self.urlbar.setCursorPosition(0)
 
+    def new_window(self, page_type):
+
+        profile = self.browser.page().profile()
+        new_page = QWebEnginePage(profile)
+        new_window = MainWindow()
+        new_window.browser.setPage(new_page)
+        new_window.show()
+
+        return new_window.browser
 
 app = QApplication(sys.argv)
 app.setApplicationName("MooseAche")


### PR DESCRIPTION
This is to address issue #7.  By creating a callback that generates a new browser window and assigning it to `MainWindow.browser.createWindow`, the browser is able to open new windows with Ctrl+click and handle `target='_blank'` links.

In the spirit of this repository, I have tried to keep the code simple and minimal.  A more proper implementation would subclass QWebEngineView or QWebEnginePage, but this approach is simple and works.